### PR TITLE
fix issue #46

### DIFF
--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -190,6 +190,31 @@ func TestBasic_Merge(t *testing.T) {
 	}
 }
 
+func TestBasic_Struct(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vdata": map[string]interface{}{
+			"vstring": "foo",
+		},
+	}
+
+	var result, inner Basic
+	result.Vdata = &inner
+	err := Decode(input, &result)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+	expected := Basic{
+		Vdata: &Basic{
+			Vstring: "foo",
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestDecode_BasicSquash(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A field of type interface{} pointing to an existing value should respect
the value type and fill in the pointed object instead of reassigning the
field with a map.